### PR TITLE
Symbolic link allow & info-file for recordings-download

### DIFF
--- a/recordings.sh
+++ b/recordings.sh
@@ -411,6 +411,7 @@ then
 				fi
 			else
 				ffmpeg -loglevel fatal -i "$(<~/ztvh/work/broadcast)/$(<~/ztvh/work/final_broadcast)" -vcodec copy -acodec copy -f mpegts -tune zerolatency -preset normal $(grep "recfolder" ~/ztvh/user/options | sed "s/recfolder=//g")/zattoo_rec_$(sed -n "$(<~/ztvh\/work\/value)p" ~/ztvh/work/recordings_list).ts & disown
+				sed -n "$(<~/ztvh\/work\/value)p" ~/ztvh/work/recordings_full >$(grep "recfolder" ~/ztvh/user/options | sed "s/recfolder=//g")/zattoo_rec_$(sed -n "$(<~/ztvh\/work\/value)p" ~/ztvh/work/recordings_list).info
 			
 				cd ~/ztvh
 			

--- a/ztvh.sh
+++ b/ztvh.sh
@@ -74,7 +74,7 @@ fi
 
 # FOLDER + FILES missing
 
-if ls -ld ~/ztvh | grep -q "drwxrwxrwx" 2> /dev/null
+if ls -ld ~/ztvh | grep -q "[dl]rwxrwxrwx" 2> /dev/null
 then
 	cd ~/ztvh
 elif [ -e ~/ztvh ]


### PR DESCRIPTION
2 changes:
- ~/ztvh is allowed to be a symbolic link, too, not only a directory
- when downloading a recording, the recording information is saved in an info-file with same directory and naming like ts-File


